### PR TITLE
DW-4347 Add Costcode and Team tags

### DIFF
--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -1,5 +1,21 @@
 meta:
   plan:
+    terraform-common-config:
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: ((dataworks.terraform_repository))
+            version: ((dataworks.terraform_version))
+            tag: ((dataworks.terraform_version))
+        params:
+          TF_INPUT: false
+          TF_CLI_ARGS_apply: -lock-timeout=300s
+          TF_CLI_ARGS_plan: -lock-timeout=300s
+          TF_VAR_slack_webhook_url: ((dataworks.slack_webhook_url))
+          TF_VAR_costcode: ((dataworks.costcode))
+
     terraform-bootstrap:
       task: terraform-bootstrap
       config:
@@ -26,20 +42,7 @@ meta:
       params:
         AWS_REGION: eu-west-2
         DEPLOY_PATH: infra
-    terraform-common-config:
-      config:
-        platform: linux
-        image_resource:
-          type: docker-image
-          source:
-            repository: ((dataworks.terraform_repository))
-            version: ((dataworks.terraform_version))
-            tag: ((dataworks.terraform_version))
-        params:
-          TF_INPUT: false
-          TF_CLI_ARGS_apply: -lock-timeout=300s
-          TF_CLI_ARGS_plan: -lock-timeout=300s
-          TF_VAR_slack_webhook_url: ((dataworks.slack_webhook_url))
+
     terraform-apply:
       task: terraform-apply
       .: (( inject meta.plan.terraform-common-config ))
@@ -59,6 +62,7 @@ meta:
         inputs:
           - name: dataworks-analytical-service-infra
           - name: terraform-config
+
     terraform-plan:
       task: terraform-plan
       .: (( inject meta.plan.terraform-common-config ))
@@ -77,6 +81,7 @@ meta:
         inputs:
           - name: dataworks-analytical-service-infra
           - name: terraform-config
+
     terraform-output:
       task: terraform-output
       .: (( inject meta.plan.terraform-common-config ))
@@ -97,6 +102,7 @@ meta:
           - name: terraform-config
         outputs:
           - name: terraform-output
+            
     create-aws-profiles:
       task: create-aws-profiles
       config:

--- a/terraform/deploy/infra/terraform.tf.j2
+++ b/terraform/deploy/infra/terraform.tf.j2
@@ -88,7 +88,7 @@ locals {
     Application  = local.name
     Persistence  = "True"
     AutoShutdown = "False"
-    Costcode     = "{{dataworks_costcode}}"
+    Costcode     = var.costcode
     Team         = "DataWorks"
   }
 

--- a/terraform/deploy/infra/terraform.tf.j2
+++ b/terraform/deploy/infra/terraform.tf.j2
@@ -88,6 +88,8 @@ locals {
     Application  = local.name
     Persistence  = "True"
     AutoShutdown = "False"
+    Costcode     = "{{dataworks_costcode}}"
+    Team         = "DataWorks"
   }
 
   cidr_block = {

--- a/terraform/deploy/infra/variables.tf
+++ b/terraform/deploy/infra/variables.tf
@@ -12,3 +12,8 @@ variable "vpc_region" {
   type        = string
   description = "(Required) The region the VPC we are deploying into is in, defaults to eu-west-2 (London)"
 }
+
+variable "costcode" {
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
The costcode is a required tag according to - http://docs.dwpcloud.uk/services/aws-account-prod.html#cost-reporting
Also adding a team tag, to help track costs across team resources. 